### PR TITLE
Update m5_stick.ssf

### DIFF
--- a/m5_stick.ssf
+++ b/m5_stick.ssf
@@ -66,5 +66,6 @@
             
             ]
         }
-    ]
+    ],
+	"is_little_endian": true
 }


### PR DESCRIPTION
SSF file produces an error message when imported into DCL due to missing endian value.